### PR TITLE
feat: Rework voting so that it doesn't use sequential vote ids

### DIFF
--- a/contracts/util/TestStaticGroup.sol
+++ b/contracts/util/TestStaticGroup.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../interfaces/IVotingWeights.sol";
+
+contract TestStaticGroup is IVotingWeights {
+    mapping(address => uint256) public override weightOf;
+
+    constructor(address[] memory initialMembers, uint256[] memory initialWeights) {
+        uint256 totalWeight = 0;
+        for (uint256 i = 0; i < initialMembers.length; i++) {
+            uint256 weight = i < initialWeights.length ? initialWeights[i] : 1;
+            totalWeight = totalWeight + weight;
+            weightOf[initialMembers[i]] = weight;
+        }
+        weightOf[address(0)] = totalWeight;
+
+    }
+
+    function weightOfAt(address member, uint256) public override view returns (uint256) {
+        return weightOf[member];
+    }
+
+    function totalWeightAt(uint256) public override view returns (uint256) {
+        return weightOf[address(0)];
+    }
+
+    function delegateOfAt(address, uint256) public override pure returns (address) {
+        return address(0);
+    }
+}

--- a/contracts/voting/IVoting.sol
+++ b/contracts/voting/IVoting.sol
@@ -6,10 +6,10 @@ pragma abicoder v2;
 import "./IVotingBase.sol";
 
 interface IVoting is IVotingBase {
-    event Vote(uint256 indexed voteId, address indexed voter, VoteStatus value);
+    event Vote(bytes32 indexed voteId, address indexed voter, VoteStatus value);
 
     enum VoteStatus { Nil, Yes, No }
 
-    function vote(uint256 voteId, VoteStatus value) external;
-    function voteOf(uint256 voteId, address voter) external returns (VoteStatus);
+    function vote(bytes32 voteId, VoteStatus value) external;
+    function voteOf(bytes32 voteId, address voter) external returns (VoteStatus);
 }

--- a/contracts/voting/IVotingBase.sol
+++ b/contracts/voting/IVotingBase.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.0;
 pragma abicoder v2;
 
 interface IVotingBase {
-    event Proposal(uint256 indexed voteId, bytes32 rationale);
-    event Enaction(uint256 indexed voteId);
+    event Proposal(bytes32 indexed voteId, bytes32 rationale, bytes32 actionsHash);
+    event Enaction(bytes32 indexed voteId, bytes32 rationale, bytes32 actionsHash);
 
     struct VoteAction {
         // uint96 value;
@@ -14,11 +14,14 @@ interface IVotingBase {
         // deadline
     }
 
-    function propose(bytes32 rationale, bytes32 actionsRoot_) external returns (uint256);
+    // voteId = keccak256(abi.encodePacked(rationale, actionsHash))
+    // actionsHash = keccak256(abi.encode(actions_));
 
-    function actionsRoot(uint256 voteId) external view returns (bytes32);
+    function propose(bytes32 rationale, bytes32 actionsHash) external returns (bytes32 voteId);
 
-    function enact(uint256 voteId, VoteAction[] calldata actions_) external; // require(keccak256(abi.encode(actions_)) == actionsRoot[voteId]);
+    function proposed(bytes32 voteId) external view returns (bool);
 
-    function enacted(uint256 voteId) external view returns (bool);
+    function enact(bytes32 rationale, VoteAction[] calldata actions) external;
+
+    function enacted(bytes32 voteId) external view returns (bool);
 }

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -53,6 +53,7 @@ describe('Gas usage scenarios', function () {
     const actionsBytes = ethers.utils.defaultAbiCoder.encode(['(address,bytes)[]'], [actions])
     const actionsHash = ethers.utils.keccak256(actionsBytes)
     const rationaleHash = ethers.utils.id('Example rationale')
+    const voteId = ethers.utils.keccak256(ethers.utils.concat([rationaleHash, actionsHash]))
 
     // Do some transactions
 
@@ -66,19 +67,19 @@ describe('Gas usage scenarios', function () {
     await (await voting.connect(userA).propose(rationaleHash, actionsHash)).wait()
 
     await advanceToBlock(startBlock + 15)
-    await (await voting.connect(userA).vote(0, 1)).wait()
+    await (await voting.connect(userA).vote(voteId, 1)).wait()
 
     await advanceToBlock(startBlock + 20)
     await (await token.connect(userB).transfer(userC.address, transferAmount)).wait()
 
     await advanceToBlock(startBlock + 25)
-    await (await voting.connect(userB).vote(0, 2)).wait()
+    await (await voting.connect(userB).vote(voteId, 2)).wait()
 
     await advanceToBlock(startBlock + 30)
-    await (await voting.connect(userC).vote(0, 1)).wait()
+    await (await voting.connect(userC).vote(voteId, 1)).wait()
 
     await advanceToBlock(startBlock + 40)
-    await (await voting.connect(userC).enact(0, actions)).wait()
+    await (await voting.connect(userC).enact(rationaleHash, actions)).wait()
 
     await advanceToBlock(startBlock + 50)
     await (await allocations.connect(userC).increaseClaim(token.address, transferAmount.div(2))).wait()


### PR DESCRIPTION
Instead, the vote id is now the hash of the rationale and actions hashes.

